### PR TITLE
feat(theory): Phase 1 — Markov chain foundations and DTMC module

### DIFF
--- a/notebooks/01_markov_foundations.ipynb
+++ b/notebooks/01_markov_foundations.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Phase 1 — Markov Chain Foundations\n",
+    "\n",
+    "Companion notebook to `notes/phase1-markov-foundations.md`. Reproduces the worked examples and the headcount classification numerically using `src.dtmc` and `src.simulation`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from src.dtmc import MarkovChain\n",
+    "from src.simulation import simulate_paths, state_distribution_at\n",
+    "\n",
+    "np.set_printoptions(precision=4, suppress=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Three-state worked example\n",
+    "\n",
+    "Compute $P^2$ and $P^3$ to match the values derived by hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P3 = np.array(\n",
+    "    [\n",
+    "        [0.7, 0.3, 0.0],\n",
+    "        [0.0, 0.8, 0.2],\n",
+    "        [0.0, 0.0, 1.0],\n",
+    "    ]\n",
+    ")\n",
+    "mc3 = MarkovChain(P3, state_labels=[\"Junior\", \"Mid\", \"Senior\"])\n",
+    "\n",
+    "print(\"P^1 =\\n\", mc3.n_step(1))\n",
+    "print(\"\\nP^2 =\\n\", mc3.n_step(2))\n",
+    "print(\"\\nP^3 =\\n\", mc3.n_step(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Headcount chain — recycling vs absorbing variants\n",
+    "\n",
+    "The recycling variant ($p_{41} = 0.5$) is irreducible. The absorbing variant ($p_{44} = 1$) splits into singleton communication classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = [\"Junior\", \"Mid\", \"Senior\", \"Exit\"]\n",
+    "\n",
+    "P_recycle = np.array(\n",
+    "    [\n",
+    "        [0.93, 0.03, 0.00, 0.04],\n",
+    "        [0.00, 0.96, 0.02, 0.02],\n",
+    "        [0.00, 0.00, 0.99, 0.01],\n",
+    "        [0.50, 0.00, 0.00, 0.50],\n",
+    "    ]\n",
+    ")\n",
+    "P_absorb = P_recycle.copy()\n",
+    "P_absorb[3] = [0.0, 0.0, 0.0, 1.0]\n",
+    "\n",
+    "mc_recycle = MarkovChain(P_recycle, state_labels=labels)\n",
+    "mc_absorb = MarkovChain(P_absorb, state_labels=labels)\n",
+    "\n",
+    "print(\"recycling:  irreducible?\", mc_recycle.is_irreducible(),\n",
+    "      \" absorbing chain?\", mc_recycle.is_absorbing())\n",
+    "print(\"absorbing:  irreducible?\", mc_absorb.is_irreducible(),\n",
+    "      \" absorbing chain?\", mc_absorb.is_absorbing())\n",
+    "\n",
+    "print(\"\\ncommunication classes (recycling):\", mc_recycle.communication_classes())\n",
+    "print(\"communication classes (absorbing):\", mc_absorb.communication_classes())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Distribution evolution\n",
+    "\n",
+    "Start with all Juniors and evolve forward 1, 6, and 12 months under the recycling variant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pi0 = np.array([1.0, 0.0, 0.0, 0.0])\n",
+    "rows = {n: mc_recycle.evolve(pi0, n) for n in (0, 1, 3, 6, 12, 24)}\n",
+    "df = pd.DataFrame(rows, index=labels).T\n",
+    "df.index.name = \"month\"\n",
+    "df.round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Empirical → analytical convergence (sanity check)\n",
+    "\n",
+    "Simulate 5{,}000 trajectories of length 12 and compare the empirical distribution at month 12 with $P^{12} \\cdot e_J$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paths = simulate_paths(mc_recycle, initial=0, n_steps=12, n_paths=5000, seed=2026)\n",
+    "empirical = state_distribution_at(paths, step=12, n_states=mc_recycle.n_states)\n",
+    "analytical = mc_recycle.evolve(pi0, 12)\n",
+    "\n",
+    "comparison = pd.DataFrame(\n",
+    "    {\"empirical\": empirical, \"P^12 · e_J\": analytical}, index=labels\n",
+    ").round(4)\n",
+    "comparison"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notes/phase1-markov-foundations.md
+++ b/notes/phase1-markov-foundations.md
@@ -1,0 +1,286 @@
+# Phase 1 — Markov Chain Foundations
+
+## 1. The Markov Property
+
+Let $\{X_n\}_{n \geq 0}$ be a sequence of random variables taking values in a finite (or countable) state space $S = \{1, 2, \ldots, K\}$. The sequence is a **Markov chain** if, for every $n \geq 0$ and every $i_0, i_1, \ldots, i_{n+1} \in S$ such that $P(X_n = i_n, \ldots, X_0 = i_0) > 0$,
+
+$$
+P(X_{n+1} = j \mid X_n = i, X_{n-1} = i_{n-1}, \ldots, X_0 = i_0) \;=\; P(X_{n+1} = j \mid X_n = i) \;=\; p_{ij}.
+$$
+
+The conditional distribution of the next state depends on the present state alone — the past adds no information beyond what $X_n$ already carries. The numbers $p_{ij}$ are the **one-step transition probabilities**, assembled into the **transition matrix**
+
+$$
+P = (p_{ij})_{i,j \in S}.
+$$
+
+Throughout this article the chain is assumed **time-homogeneous**: $p_{ij}$ does not depend on $n$.
+
+### 1.1 The transition matrix is row-stochastic
+
+**Claim.** $p_{ij} \geq 0$ for all $i, j$, and $\sum_{j \in S} p_{ij} = 1$ for every $i$.
+
+**Proof.** Non-negativity is immediate from the definition of probability. For each fixed $i$,
+
+$$
+\sum_{j \in S} p_{ij} \;=\; \sum_{j \in S} P(X_{n+1} = j \mid X_n = i) \;=\; P\!\left(\bigcup_{j \in S} \{X_{n+1} = j\} \,\Big|\, X_n = i\right) \;=\; 1,
+$$
+
+since the events $\{X_{n+1} = j\}$ for $j \in S$ form a partition of the sample space (the chain must be in some state at time $n+1$). $\blacksquare$
+
+Equivalently, $P \mathbf{1} = \mathbf{1}$ where $\mathbf{1} = (1, \ldots, 1)^T$. Each row of $P$ is a probability distribution over the next state.
+
+---
+
+## 2. $n$-Step Transitions and Chapman–Kolmogorov
+
+### 2.1 Definition
+
+The **$n$-step transition probability** is
+
+$$
+p_{ij}^{(n)} \;=\; P(X_n = j \mid X_0 = i).
+$$
+
+By convention $p_{ij}^{(0)} = \delta_{ij}$ (Kronecker delta) and $p_{ij}^{(1)} = p_{ij}$.
+
+### 2.2 Theorem ($n$-step matrix)
+
+**Claim.** $p_{ij}^{(n)} = (P^n)_{ij}$ for every $n \geq 0$.
+
+**Proof (induction on $n$).** The base case $n = 0$ holds by convention. Assume $p_{ij}^{(n)} = (P^n)_{ij}$ for some $n \geq 0$. Conditioning on $X_n$,
+
+$$
+p_{ij}^{(n+1)} \;=\; P(X_{n+1} = j \mid X_0 = i) \;=\; \sum_{k \in S} P(X_{n+1} = j, X_n = k \mid X_0 = i).
+$$
+
+Apply the multiplication rule and the Markov property:
+
+$$
+P(X_{n+1} = j, X_n = k \mid X_0 = i) \;=\; P(X_{n+1} = j \mid X_n = k) \cdot P(X_n = k \mid X_0 = i) \;=\; p_{kj} \cdot p_{ik}^{(n)}.
+$$
+
+Hence
+
+$$
+p_{ij}^{(n+1)} \;=\; \sum_{k \in S} p_{ik}^{(n)} \, p_{kj} \;=\; \sum_{k \in S} (P^n)_{ik} \, P_{kj} \;=\; (P^{n+1})_{ij}. \quad\blacksquare
+$$
+
+### 2.3 Theorem (Chapman–Kolmogorov)
+
+**Claim.** For every $m, n \geq 0$ and every $i, j \in S$,
+
+$$
+p_{ij}^{(m+n)} \;=\; \sum_{k \in S} p_{ik}^{(m)} \, p_{kj}^{(n)}.
+$$
+
+**Proof.** Conditioning on $X_m$, then applying the Markov property and time-homogeneity,
+
+$$
+p_{ij}^{(m+n)}
+= P(X_{m+n} = j \mid X_0 = i)
+= \sum_{k} P(X_{m+n} = j, X_m = k \mid X_0 = i)
+$$
+
+$$
+= \sum_{k} P(X_{m+n} = j \mid X_m = k) \cdot P(X_m = k \mid X_0 = i)
+= \sum_{k} p_{kj}^{(n)} \, p_{ik}^{(m)}. \quad\blacksquare
+$$
+
+In matrix form: $P^{m+n} = P^m P^n$. The Chapman–Kolmogorov equation is the probabilistic content of matrix multiplication associativity.
+
+### 2.4 Corollary ($P^n$ is row-stochastic)
+
+By induction, $(P^{n+1}) \mathbf{1} = P^n (P \mathbf{1}) = P^n \mathbf{1} = \mathbf{1}$. Every $n$-step transition matrix is itself row-stochastic.
+
+### 2.5 Distribution evolution
+
+If $\pi_n = (P(X_n = 1), \ldots, P(X_n = K))$ is the row vector of marginal probabilities at time $n$, then
+
+$$
+\pi_{n+1} \;=\; \pi_n \, P, \qquad \pi_n \;=\; \pi_0 \, P^n.
+$$
+
+The distribution flows by **right multiplication by $P$**. This is the convention used throughout the article.
+
+---
+
+## 3. State Classification
+
+Fix the chain $\{X_n\}$ with transition matrix $P$.
+
+### 3.1 Accessibility and communication
+
+State $j$ is **accessible from** state $i$, written $i \to j$, if $p_{ij}^{(n)} > 0$ for some $n \geq 0$.
+
+States $i$ and $j$ **communicate**, written $i \leftrightarrow j$, if both $i \to j$ and $j \to i$.
+
+### 3.2 Theorem (communication is an equivalence relation)
+
+**Claim.** The relation $\leftrightarrow$ on $S$ is reflexive, symmetric, and transitive.
+
+**Proof.**
+
+- **Reflexivity.** $p_{ii}^{(0)} = 1 > 0$, so $i \to i$. Hence $i \leftrightarrow i$.
+- **Symmetry.** Immediate from the definition.
+- **Transitivity.** Suppose $i \leftrightarrow j$ and $j \leftrightarrow k$. There exist $m_1, n_1 \geq 0$ with $p_{ij}^{(m_1)} > 0$ and $p_{ji}^{(n_1)} > 0$, and $m_2, n_2 \geq 0$ with $p_{jk}^{(m_2)} > 0$ and $p_{kj}^{(n_2)} > 0$. By Chapman–Kolmogorov,
+
+  $$
+  p_{ik}^{(m_1 + m_2)} \;=\; \sum_{\ell} p_{i\ell}^{(m_1)} \, p_{\ell k}^{(m_2)} \;\geq\; p_{ij}^{(m_1)} \, p_{jk}^{(m_2)} \;>\; 0.
+  $$
+
+  Symmetrically $p_{ki}^{(n_2 + n_1)} \geq p_{kj}^{(n_2)} p_{ji}^{(n_1)} > 0$. Hence $i \leftrightarrow k$. $\blacksquare$
+
+The equivalence classes of $\leftrightarrow$ are the **communication classes**. The chain is **irreducible** if there is exactly one communication class — every state is reachable from every other.
+
+### 3.3 Recurrence and transience
+
+For a state $i$, define the **return time** $T_i = \min\{n \geq 1 : X_n = i\}$ (with $T_i = \infty$ if no return). Let $f_i = P(T_i < \infty \mid X_0 = i)$.
+
+State $i$ is **recurrent** if $f_i = 1$ and **transient** if $f_i < 1$.
+
+Equivalent characterisation:
+
+- $i$ is recurrent $\iff \sum_{n=0}^{\infty} p_{ii}^{(n)} = \infty$.
+- $i$ is transient $\iff \sum_{n=0}^{\infty} p_{ii}^{(n)} < \infty$.
+
+A useful fact (proof sketched in references): all states in the same communication class are of the same type. In particular, in an irreducible finite chain every state is recurrent.
+
+### 3.4 Absorbing states
+
+A state $i$ is **absorbing** if $p_{ii} = 1$, equivalently if $\{i\}$ is a communication class with $i \not\to j$ for any $j \neq i$. An **absorbing chain** is one in which every state is either absorbing or eventually reaches an absorbing state with positive probability.
+
+### 3.5 Periodicity
+
+The **period** of state $i$ is
+
+$$
+d(i) \;=\; \gcd\{n \geq 1 : p_{ii}^{(n)} > 0\}.
+$$
+
+State $i$ is **aperiodic** if $d(i) = 1$, **periodic** otherwise. Periodicity is a class property: if $i \leftrightarrow j$ then $d(i) = d(j)$.
+
+---
+
+## 4. Application: the Headcount Chain
+
+Take Formulation A from the model design with replacement hiring, $p_{41} = 0.5$:
+
+$$
+P = \begin{pmatrix}
+0.93 & 0.03 & 0    & 0.04 \\
+0    & 0.96 & 0.02 & 0.02 \\
+0    & 0    & 0.99 & 0.01 \\
+0.50 & 0    & 0    & 0.50
+\end{pmatrix}, \qquad S = \{\mathrm{J}, \mathrm{M}, \mathrm{S}, \mathrm{E}\}.
+$$
+
+### 4.1 Accessibility graph
+
+| from \ to | J | M | S | E |
+|-----------|---|---|---|---|
+| J         | ✓ | ✓ |   | ✓ |
+| M         |   | ✓ | ✓ | ✓ |
+| S         |   |   | ✓ | ✓ |
+| E         | ✓ |   |   | ✓ |
+
+Direct arrows: $\mathrm{J} \to \mathrm{M}$, $\mathrm{M} \to \mathrm{S}$, $\mathrm{J,M,S} \to \mathrm{E}$, $\mathrm{E} \to \mathrm{J}$.
+
+### 4.2 Communication classes
+
+- $\mathrm{J} \to \mathrm{M}$ via $p_{12}$. Reverse: $\mathrm{M} \to \mathrm{S} \to \mathrm{E} \to \mathrm{J}$ has positive probability, so $\mathrm{M} \to \mathrm{J}$. Hence $\mathrm{J} \leftrightarrow \mathrm{M}$.
+- $\mathrm{M} \to \mathrm{S}$ via $p_{23}$. Reverse: $\mathrm{S} \to \mathrm{E} \to \mathrm{J} \to \mathrm{M}$, so $\mathrm{S} \to \mathrm{M}$.
+- $\mathrm{S} \to \mathrm{E}$ via $p_{34}$. Reverse: $\mathrm{E} \to \mathrm{J} \to \mathrm{M} \to \mathrm{S}$, so $\mathrm{E} \to \mathrm{S}$.
+
+All four states communicate. The chain is **irreducible**. Every state is recurrent. Aperiodicity follows from $p_{ii} > 0$ for every $i$ (each state has a self-loop), so $d(i) = 1$.
+
+### 4.3 The absorbing variant
+
+Set $p_{41} = 0$, $p_{44} = 1$. Now $\mathrm{E}$ is absorbing. Communication classes become $\{\mathrm{J}, \mathrm{M}, \mathrm{S}\}$ no longer communicate (because $\mathrm{E}$ no longer routes back), and each transient class is in fact a singleton: $\{\mathrm{J}\}, \{\mathrm{M}\}, \{\mathrm{S}\}, \{\mathrm{E}\}$. The transient states $\mathrm{J}, \mathrm{M}, \mathrm{S}$ all reach $\mathrm{E}$ in finite expected time (Phase 3 makes this quantitative).
+
+---
+
+## 5. Worked Example — 3-state chain
+
+Take a simplified chain with states $\{\mathrm{J}, \mathrm{M}, \mathrm{S}\}$ (absorbing variant collapsed by ignoring exits):
+
+$$
+P = \begin{pmatrix}
+0.7 & 0.3 & 0   \\
+0   & 0.8 & 0.2 \\
+0   & 0   & 1
+\end{pmatrix}.
+$$
+
+### 5.1 Compute $P^2$
+
+$$
+P^2 = \begin{pmatrix}
+0.7 & 0.3 & 0 \\
+0 & 0.8 & 0.2 \\
+0 & 0 & 1
+\end{pmatrix}
+\begin{pmatrix}
+0.7 & 0.3 & 0 \\
+0 & 0.8 & 0.2 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+0.49 & 0.45 & 0.06 \\
+0    & 0.64 & 0.36 \\
+0    & 0    & 1
+\end{pmatrix}.
+$$
+
+Sanity checks: rows sum to $0.49 + 0.45 + 0.06 = 1$, $0.64 + 0.36 = 1$, $1$. ✓
+
+Interpretation:
+
+- $p_{\mathrm{JJ}}^{(2)} = 0.49$: a Junior is still Junior after 2 months with probability 49%.
+- $p_{\mathrm{JM}}^{(2)} = 0.45$: a Junior is Mid after 2 months with probability 45%.
+- $p_{\mathrm{JS}}^{(2)} = 0.06$: a Junior is Senior after 2 months with probability 6%.
+
+### 5.2 Compute $P^3 = P^2 \cdot P$
+
+$$
+P^3 = \begin{pmatrix}
+0.49 & 0.45 & 0.06 \\
+0    & 0.64 & 0.36 \\
+0    & 0    & 1
+\end{pmatrix}
+\begin{pmatrix}
+0.7 & 0.3 & 0 \\
+0 & 0.8 & 0.2 \\
+0 & 0 & 1
+\end{pmatrix}
+= \begin{pmatrix}
+0.343 & 0.507 & 0.150 \\
+0     & 0.512 & 0.488 \\
+0     & 0     & 1
+\end{pmatrix}.
+$$
+
+After 3 months the Junior probability has fallen from 0.7 to 0.343, while the Senior probability has grown from 0 to 0.150.
+
+### 5.3 State classification of the 3-state chain
+
+- $\mathrm{S}$ is absorbing: $p_{\mathrm{SS}} = 1$.
+- $\mathrm{J}, \mathrm{M}$ are transient: from either, the chain reaches $\mathrm{S}$ with positive probability and never returns.
+
+The chain is **not irreducible**; it has three communication classes: $\{\mathrm{J}\}$, $\{\mathrm{M}\}$, $\{\mathrm{S}\}$.
+
+---
+
+## 6. Summary
+
+- A Markov chain is fully specified by its state space $S$ and transition matrix $P$.
+- $P$ is row-stochastic; $P^n$ is row-stochastic for all $n \geq 0$.
+- Chapman–Kolmogorov: $P^{m+n} = P^m P^n$. Distributions evolve via $\pi_n = \pi_0 P^n$.
+- Communication is an equivalence relation. Recurrence and periodicity are class properties.
+- The headcount chain with replacement hiring is irreducible, aperiodic, finite — and therefore positive recurrent (Phase 2 will compute its stationary distribution).
+
+## References
+
+- Norris, *Markov Chains*, Cambridge UP, 1997 — Ch. 1.
+- Ross, *Introduction to Probability Models*, Academic Press, 11th ed., 2014 — Ch. 4.
+- Grinstead & Snell, *Introduction to Probability*, AMS, 1997 — Ch. 11.

--- a/src/dtmc.py
+++ b/src/dtmc.py
@@ -1,0 +1,197 @@
+"""Discrete-time Markov chain (DTMC) module.
+
+Wraps a row-stochastic transition matrix P and provides:
+
+- n-step transitions P^n
+- a placeholder for the stationary distribution (full solver in Phase 2)
+- structural queries: irreducibility, absorption, communication classes
+
+Conventions:
+
+- States are indexed 0, 1, ..., K-1.
+- Distributions are row vectors. They evolve by right-multiplication: pi_{n+1} = pi_n P.
+- Each row of P is a conditional distribution and sums to 1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+from numpy.typing import NDArray
+
+ArrayF = NDArray[np.float64]
+
+
+@dataclass
+class MarkovChain:
+    """A finite-state, time-homogeneous discrete-time Markov chain.
+
+    Attributes:
+        P: Transition matrix of shape (K, K). Must be row-stochastic.
+        state_labels: Optional human-readable labels, length K.
+        atol: Numerical tolerance used in row-sum and equality checks.
+    """
+
+    P: ArrayF
+    state_labels: list[str] = field(default_factory=list)
+    atol: float = 1e-9
+
+    def __post_init__(self) -> None:
+        P = np.asarray(self.P, dtype=np.float64)
+        if P.ndim != 2 or P.shape[0] != P.shape[1]:
+            raise ValueError(f"P must be a square 2D array; got shape {P.shape}.")
+        if np.any(P < -self.atol):
+            raise ValueError("P contains negative entries.")
+        row_sums = P.sum(axis=1)
+        if not np.allclose(row_sums, 1.0, atol=self.atol):
+            raise ValueError(
+                f"Rows of P must sum to 1 (within atol={self.atol}); got {row_sums}."
+            )
+        # Clip tiny negative noise to zero for safety.
+        self.P = np.clip(P, 0.0, None)
+
+        K = self.P.shape[0]
+        if not self.state_labels:
+            self.state_labels = [str(i) for i in range(K)]
+        elif len(self.state_labels) != K:
+            raise ValueError(
+                f"state_labels has length {len(self.state_labels)}, expected {K}."
+            )
+
+    # ──────────────────────────────────────────────────────────────────
+    # Basic structure
+    # ──────────────────────────────────────────────────────────────────
+
+    @property
+    def n_states(self) -> int:
+        """Number of states K."""
+        return int(self.P.shape[0])
+
+    def n_step(self, n: int) -> ArrayF:
+        """Return the n-step transition matrix P^n.
+
+        Args:
+            n: Non-negative integer.
+
+        Returns:
+            Array of shape (K, K) equal to P^n. P^0 is the identity.
+        """
+        if n < 0:
+            raise ValueError("n must be non-negative.")
+        return np.linalg.matrix_power(self.P, n)
+
+    def evolve(self, pi0: Sequence[float], n: int) -> ArrayF:
+        """Evolve a distribution forward by n steps: pi_n = pi_0 P^n.
+
+        Args:
+            pi0: Initial distribution, length K, non-negative, sums to 1.
+            n: Non-negative integer.
+
+        Returns:
+            Row vector pi_n.
+        """
+        pi = np.asarray(pi0, dtype=np.float64).reshape(-1)
+        if pi.size != self.n_states:
+            raise ValueError(f"pi0 must have length {self.n_states}.")
+        if not np.isclose(pi.sum(), 1.0, atol=self.atol) or np.any(pi < -self.atol):
+            raise ValueError("pi0 must be a probability vector.")
+        return pi @ self.n_step(n)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Stationary distribution (placeholder; full Phase 2 solver later)
+    # ──────────────────────────────────────────────────────────────────
+
+    def stationary(self) -> ArrayF:
+        """Return a stationary distribution pi such that pi P = pi.
+
+        Phase 1 placeholder: solves the linear system using the left
+        eigenvector of P with eigenvalue 1. For multiple stationary
+        distributions (reducible chains) the result is one valid solution
+        with no guarantee of uniqueness; Phase 2 develops the full theory.
+
+        Returns:
+            Row vector of length K, non-negative, summing to 1.
+        """
+        # Solve pi (P - I) = 0 with sum(pi) = 1 via least squares.
+        K = self.n_states
+        A = np.vstack([(self.P.T - np.eye(K)), np.ones(K)])
+        b = np.zeros(K + 1)
+        b[-1] = 1.0
+        pi, *_ = np.linalg.lstsq(A, b, rcond=None)
+        pi = np.clip(pi, 0.0, None)
+        s = pi.sum()
+        if s == 0.0:
+            raise RuntimeError("Stationary solver produced the zero vector.")
+        return pi / s
+
+    # ──────────────────────────────────────────────────────────────────
+    # Structural properties
+    # ──────────────────────────────────────────────────────────────────
+
+    def _reachability(self) -> NDArray[np.bool_]:
+        """Boolean matrix R where R[i, j] = True iff j is accessible from i."""
+        K = self.n_states
+        R = self.P > 0.0
+        # Diagonal: i is accessible from i in 0 steps.
+        np.fill_diagonal(R, True)
+        # Transitive closure (Warshall).
+        for k in range(K):
+            R = R | (R[:, [k]] & R[[k], :])
+        return R
+
+    def is_irreducible(self) -> bool:
+        """True iff every state is accessible from every other state."""
+        return bool(self._reachability().all())
+
+    def is_absorbing_state(self, i: int) -> bool:
+        """True iff state i is absorbing (p_ii == 1)."""
+        return bool(np.isclose(self.P[i, i], 1.0, atol=self.atol))
+
+    def is_absorbing(self) -> bool:
+        """True iff the chain has at least one absorbing state and every
+        state can eventually reach some absorbing state.
+        """
+        absorbing = [i for i in range(self.n_states) if self.is_absorbing_state(i)]
+        if not absorbing:
+            return False
+        R = self._reachability()
+        for i in range(self.n_states):
+            if not any(R[i, a] for a in absorbing):
+                return False
+        return True
+
+    def communication_classes(self) -> list[set[int]]:
+        """Return the equivalence classes of the 'communicates with' relation.
+
+        Two states i, j are in the same class iff i is accessible from j and
+        j is accessible from i.
+        """
+        R = self._reachability()
+        # i communicates with j iff R[i,j] and R[j,i].
+        comm = R & R.T
+        K = self.n_states
+        seen: set[int] = set()
+        classes: list[set[int]] = []
+        for i in range(K):
+            if i in seen:
+                continue
+            cls = {j for j in range(K) if comm[i, j]}
+            classes.append(cls)
+            seen |= cls
+        return classes
+
+    # ──────────────────────────────────────────────────────────────────
+    # Convenience
+    # ──────────────────────────────────────────────────────────────────
+
+    def label(self, i: int) -> str:
+        """Return the human-readable label of state i."""
+        return self.state_labels[i]
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (
+            f"MarkovChain(n_states={self.n_states}, "
+            f"labels={self.state_labels})"
+        )

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,0 +1,108 @@
+"""Path simulation for discrete-time Markov chains.
+
+Generates trajectories by sampling next states from the rows of the transition
+matrix. All randomness flows through an explicit ``numpy.random.Generator`` so
+results are reproducible from a single seed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .dtmc import MarkovChain
+
+ArrayI = NDArray[np.int64]
+ArrayF = NDArray[np.float64]
+
+
+def simulate_path(
+    mc: MarkovChain,
+    initial: int,
+    n_steps: int,
+    seed: int | None = None,
+) -> ArrayI:
+    """Simulate a single path of length ``n_steps + 1`` starting at ``initial``.
+
+    Args:
+        mc: A MarkovChain.
+        initial: Starting state index in [0, K).
+        n_steps: Number of transitions to sample. The returned path has
+            ``n_steps + 1`` entries (initial state plus ``n_steps`` next states).
+        seed: Optional seed for the random generator.
+
+    Returns:
+        Integer array of length ``n_steps + 1`` containing the visited states.
+    """
+    if not (0 <= initial < mc.n_states):
+        raise ValueError(f"initial must be in [0, {mc.n_states}); got {initial}.")
+    if n_steps < 0:
+        raise ValueError("n_steps must be non-negative.")
+
+    rng = np.random.default_rng(seed)
+    path = np.empty(n_steps + 1, dtype=np.int64)
+    path[0] = initial
+    states = np.arange(mc.n_states)
+    for t in range(n_steps):
+        path[t + 1] = rng.choice(states, p=mc.P[path[t]])
+    return path
+
+
+def simulate_paths(
+    mc: MarkovChain,
+    initial: int,
+    n_steps: int,
+    n_paths: int,
+    seed: int | None = None,
+) -> ArrayI:
+    """Simulate ``n_paths`` independent trajectories.
+
+    Args:
+        mc: A MarkovChain.
+        initial: Starting state index, identical across paths.
+        n_steps: Number of transitions per path.
+        n_paths: Number of paths.
+        seed: Optional seed; uses a single ``Generator`` to sample all paths.
+
+    Returns:
+        Integer array of shape ``(n_paths, n_steps + 1)``.
+    """
+    if n_paths <= 0:
+        raise ValueError("n_paths must be positive.")
+    if not (0 <= initial < mc.n_states):
+        raise ValueError(f"initial must be in [0, {mc.n_states}); got {initial}.")
+    if n_steps < 0:
+        raise ValueError("n_steps must be non-negative.")
+
+    rng = np.random.default_rng(seed)
+    paths = np.empty((n_paths, n_steps + 1), dtype=np.int64)
+    paths[:, 0] = initial
+    states = np.arange(mc.n_states)
+
+    for t in range(n_steps):
+        for k in range(n_paths):
+            paths[k, t + 1] = rng.choice(states, p=mc.P[paths[k, t]])
+    return paths
+
+
+def state_distribution_at(paths: ArrayI, step: int, n_states: int) -> ArrayF:
+    """Empirical distribution over states at a given time step.
+
+    Args:
+        paths: Array of shape ``(n_paths, n_steps + 1)``.
+        step: Time index in ``[0, n_steps]``.
+        n_states: Total number of states K (paths may not cover all of them).
+
+    Returns:
+        Float array of length K with empirical proportions, summing to 1.
+    """
+    if paths.ndim != 2:
+        raise ValueError(f"paths must be 2D; got shape {paths.shape}.")
+    if not (0 <= step < paths.shape[1]):
+        raise ValueError(f"step must be in [0, {paths.shape[1]}); got {step}.")
+
+    counts = np.bincount(paths[:, step], minlength=n_states).astype(np.float64)
+    total = counts.sum()
+    if total == 0:
+        raise ValueError("No samples found at the requested step.")
+    return counts / total

--- a/tests/test_dtmc.py
+++ b/tests/test_dtmc.py
@@ -1,0 +1,228 @@
+"""Tests for src/dtmc.py — MarkovChain class."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.dtmc import MarkovChain
+
+# Shared fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def headcount_recycling() -> MarkovChain:
+    """Headcount model with replacement hiring (irreducible)."""
+    P = np.array(
+        [
+            [0.93, 0.03, 0.00, 0.04],
+            [0.00, 0.96, 0.02, 0.02],
+            [0.00, 0.00, 0.99, 0.01],
+            [0.50, 0.00, 0.00, 0.50],
+        ]
+    )
+    return MarkovChain(P, state_labels=["Junior", "Mid", "Senior", "Exit"])
+
+
+@pytest.fixture
+def headcount_absorbing() -> MarkovChain:
+    """Headcount model with Exit absorbing (no replacement hiring)."""
+    P = np.array(
+        [
+            [0.93, 0.03, 0.00, 0.04],
+            [0.00, 0.96, 0.02, 0.02],
+            [0.00, 0.00, 0.99, 0.01],
+            [0.00, 0.00, 0.00, 1.00],
+        ]
+    )
+    return MarkovChain(P, state_labels=["Junior", "Mid", "Senior", "Exit"])
+
+
+@pytest.fixture
+def three_state_upper() -> MarkovChain:
+    """3-state upper-triangular chain from worked example in notes."""
+    P = np.array(
+        [
+            [0.7, 0.3, 0.0],
+            [0.0, 0.8, 0.2],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    return MarkovChain(P)
+
+
+# Construction & validation ────────────────────────────────────────────────
+
+
+class TestConstruction:
+    def test_rejects_non_square(self) -> None:
+        with pytest.raises(ValueError, match="square"):
+            MarkovChain(np.array([[0.5, 0.5]]))
+
+    def test_rejects_negative_entries(self) -> None:
+        P = np.array([[0.5, 0.6, -0.1], [1, 0, 0], [0, 0, 1]])
+        with pytest.raises(ValueError, match="negative"):
+            MarkovChain(P)
+
+    def test_rejects_non_stochastic_rows(self) -> None:
+        P = np.array([[0.5, 0.4], [0.0, 1.0]])
+        with pytest.raises(ValueError, match="sum to 1"):
+            MarkovChain(P)
+
+    def test_default_labels(self, three_state_upper: MarkovChain) -> None:
+        assert three_state_upper.state_labels == ["0", "1", "2"]
+
+    def test_label_length_mismatch(self) -> None:
+        P = np.eye(3)
+        with pytest.raises(ValueError, match="length"):
+            MarkovChain(P, state_labels=["a", "b"])
+
+    def test_n_states(self, headcount_recycling: MarkovChain) -> None:
+        assert headcount_recycling.n_states == 4
+
+
+# Theorem: P^1 = P, P^n is row-stochastic, distribution evolution ─────────
+
+
+class TestNStep:
+    def test_p1_equals_p(self, three_state_upper: MarkovChain) -> None:
+        np.testing.assert_allclose(three_state_upper.n_step(1), three_state_upper.P)
+
+    def test_p0_is_identity(self, three_state_upper: MarkovChain) -> None:
+        np.testing.assert_allclose(
+            three_state_upper.n_step(0), np.eye(three_state_upper.n_states)
+        )
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 5, 10, 25, 100])
+    def test_pn_rows_sum_to_one(
+        self, headcount_recycling: MarkovChain, n: int
+    ) -> None:
+        Pn = headcount_recycling.n_step(n)
+        np.testing.assert_allclose(Pn.sum(axis=1), np.ones(Pn.shape[0]), atol=1e-10)
+
+    @pytest.mark.parametrize("n", [1, 2, 5, 10])
+    def test_pn_non_negative(
+        self, headcount_recycling: MarkovChain, n: int
+    ) -> None:
+        Pn = headcount_recycling.n_step(n)
+        assert (Pn >= -1e-12).all()
+
+    def test_negative_n_rejected(self, three_state_upper: MarkovChain) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            three_state_upper.n_step(-1)
+
+    def test_p2_matches_worked_example(self, three_state_upper: MarkovChain) -> None:
+        expected = np.array(
+            [
+                [0.49, 0.45, 0.06],
+                [0.00, 0.64, 0.36],
+                [0.00, 0.00, 1.00],
+            ]
+        )
+        np.testing.assert_allclose(three_state_upper.n_step(2), expected, atol=1e-12)
+
+    def test_p3_matches_worked_example(self, three_state_upper: MarkovChain) -> None:
+        expected = np.array(
+            [
+                [0.343, 0.507, 0.150],
+                [0.000, 0.512, 0.488],
+                [0.000, 0.000, 1.000],
+            ]
+        )
+        np.testing.assert_allclose(three_state_upper.n_step(3), expected, atol=1e-12)
+
+    def test_chapman_kolmogorov(self, headcount_recycling: MarkovChain) -> None:
+        """P^{m+n} = P^m P^n for several (m, n)."""
+        for m, n in [(1, 1), (2, 3), (5, 7), (10, 4)]:
+            Pmn = headcount_recycling.n_step(m + n)
+            Pm_Pn = headcount_recycling.n_step(m) @ headcount_recycling.n_step(n)
+            np.testing.assert_allclose(Pmn, Pm_Pn, atol=1e-10)
+
+
+class TestEvolve:
+    def test_evolve_one_step(self, three_state_upper: MarkovChain) -> None:
+        pi0 = np.array([1.0, 0.0, 0.0])
+        pi1 = three_state_upper.evolve(pi0, 1)
+        np.testing.assert_allclose(pi1, np.array([0.7, 0.3, 0.0]))
+
+    def test_evolve_matches_pn(self, headcount_recycling: MarkovChain) -> None:
+        pi0 = np.array([1.0, 0.0, 0.0, 0.0])
+        for n in [1, 5, 12]:
+            pi_n_evolve = headcount_recycling.evolve(pi0, n)
+            pi_n_matrix = pi0 @ headcount_recycling.n_step(n)
+            np.testing.assert_allclose(pi_n_evolve, pi_n_matrix, atol=1e-12)
+
+    def test_invalid_pi0(self, three_state_upper: MarkovChain) -> None:
+        with pytest.raises(ValueError, match="probability"):
+            three_state_upper.evolve(np.array([0.5, 0.4, 0.0]), 1)
+
+
+# Stationary distribution (placeholder) ───────────────────────────────────
+
+
+class TestStationaryPlaceholder:
+    def test_stationary_satisfies_pi_p_equals_pi(
+        self, headcount_recycling: MarkovChain
+    ) -> None:
+        pi = headcount_recycling.stationary()
+        np.testing.assert_allclose(pi @ headcount_recycling.P, pi, atol=1e-8)
+
+    def test_stationary_is_a_distribution(
+        self, headcount_recycling: MarkovChain
+    ) -> None:
+        pi = headcount_recycling.stationary()
+        assert (pi >= 0).all()
+        assert np.isclose(pi.sum(), 1.0)
+
+
+# Structural properties ──────────────────────────────────────────────────
+
+
+class TestStructure:
+    def test_recycling_is_irreducible(
+        self, headcount_recycling: MarkovChain
+    ) -> None:
+        assert headcount_recycling.is_irreducible() is True
+
+    def test_absorbing_is_not_irreducible(
+        self, headcount_recycling: MarkovChain, headcount_absorbing: MarkovChain
+    ) -> None:
+        assert headcount_absorbing.is_irreducible() is False
+
+    def test_recycling_has_one_communication_class(
+        self, headcount_recycling: MarkovChain
+    ) -> None:
+        classes = headcount_recycling.communication_classes()
+        assert len(classes) == 1
+        assert classes[0] == {0, 1, 2, 3}
+
+    def test_absorbing_communication_classes(
+        self, headcount_absorbing: MarkovChain
+    ) -> None:
+        classes = headcount_absorbing.communication_classes()
+        # Each transient state and the absorbing state form their own class.
+        as_frozen = {frozenset(c) for c in classes}
+        assert as_frozen == {
+            frozenset({0}),
+            frozenset({1}),
+            frozenset({2}),
+            frozenset({3}),
+        }
+
+    def test_is_absorbing_state(
+        self, headcount_absorbing: MarkovChain, headcount_recycling: MarkovChain
+    ) -> None:
+        assert headcount_absorbing.is_absorbing_state(3) is True
+        for i in range(3):
+            assert headcount_absorbing.is_absorbing_state(i) is False
+        for i in range(headcount_recycling.n_states):
+            assert headcount_recycling.is_absorbing_state(i) is False
+
+    def test_is_absorbing_chain(
+        self, headcount_absorbing: MarkovChain, headcount_recycling: MarkovChain
+    ) -> None:
+        assert headcount_absorbing.is_absorbing() is True
+        assert headcount_recycling.is_absorbing() is False
+
+    def test_label_lookup(self, headcount_recycling: MarkovChain) -> None:
+        assert headcount_recycling.label(2) == "Senior"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,145 @@
+"""Tests for src/simulation.py — path simulation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.dtmc import MarkovChain
+from src.simulation import simulate_path, simulate_paths, state_distribution_at
+
+
+@pytest.fixture
+def chain() -> MarkovChain:
+    P = np.array(
+        [
+            [0.93, 0.03, 0.00, 0.04],
+            [0.00, 0.96, 0.02, 0.02],
+            [0.00, 0.00, 0.99, 0.01],
+            [0.50, 0.00, 0.00, 0.50],
+        ]
+    )
+    return MarkovChain(P, state_labels=["Junior", "Mid", "Senior", "Exit"])
+
+
+# simulate_path ──────────────────────────────────────────────────────────
+
+
+class TestSimulatePath:
+    def test_path_shape(self, chain: MarkovChain) -> None:
+        path = simulate_path(chain, initial=0, n_steps=10, seed=42)
+        assert path.shape == (11,)
+
+    def test_starts_at_initial(self, chain: MarkovChain) -> None:
+        for s in range(chain.n_states):
+            path = simulate_path(chain, initial=s, n_steps=5, seed=0)
+            assert path[0] == s
+
+    def test_visits_only_valid_states(self, chain: MarkovChain) -> None:
+        path = simulate_path(chain, initial=0, n_steps=200, seed=7)
+        assert path.min() >= 0
+        assert path.max() < chain.n_states
+
+    def test_respects_zero_transitions(self) -> None:
+        # Junior can never directly become Senior — that arc is forbidden.
+        P = np.array(
+            [
+                [0.5, 0.5, 0.0],
+                [0.0, 0.5, 0.5],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        mc = MarkovChain(P)
+        path = simulate_path(mc, initial=0, n_steps=500, seed=1)
+        # No 0 → 2 jump in a single step.
+        for t in range(len(path) - 1):
+            if path[t] == 0:
+                assert path[t + 1] in (0, 1)
+
+    def test_seeded_paths_are_reproducible(self, chain: MarkovChain) -> None:
+        a = simulate_path(chain, initial=0, n_steps=50, seed=123)
+        b = simulate_path(chain, initial=0, n_steps=50, seed=123)
+        np.testing.assert_array_equal(a, b)
+
+    def test_different_seeds_differ(self, chain: MarkovChain) -> None:
+        a = simulate_path(chain, initial=0, n_steps=200, seed=1)
+        b = simulate_path(chain, initial=0, n_steps=200, seed=2)
+        # Two long paths from different seeds should disagree somewhere.
+        assert not np.array_equal(a, b)
+
+    def test_invalid_initial(self, chain: MarkovChain) -> None:
+        with pytest.raises(ValueError, match="initial"):
+            simulate_path(chain, initial=99, n_steps=1, seed=0)
+
+    def test_n_steps_zero(self, chain: MarkovChain) -> None:
+        path = simulate_path(chain, initial=2, n_steps=0, seed=0)
+        assert path.shape == (1,)
+        assert path[0] == 2
+
+    def test_negative_n_steps(self, chain: MarkovChain) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            simulate_path(chain, initial=0, n_steps=-1, seed=0)
+
+
+# simulate_paths ─────────────────────────────────────────────────────────
+
+
+class TestSimulatePaths:
+    def test_paths_shape(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=0, n_steps=10, n_paths=50, seed=0)
+        assert paths.shape == (50, 11)
+
+    def test_all_paths_start_at_initial(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=1, n_steps=5, n_paths=20, seed=0)
+        assert (paths[:, 0] == 1).all()
+
+    def test_all_visited_states_valid(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=0, n_steps=20, n_paths=100, seed=0)
+        assert paths.min() >= 0
+        assert paths.max() < chain.n_states
+
+    def test_invalid_n_paths(self, chain: MarkovChain) -> None:
+        with pytest.raises(ValueError, match="n_paths"):
+            simulate_paths(chain, initial=0, n_steps=1, n_paths=0, seed=0)
+
+
+# Empirical → analytical convergence ─────────────────────────────────────
+
+
+class TestEmpiricalConvergence:
+    def test_distribution_converges_to_pn_e_initial(
+        self, chain: MarkovChain
+    ) -> None:
+        """Empirical distribution at step n approaches P^n applied to e_initial."""
+        n_steps = 5
+        n_paths = 5000
+        initial = 0
+        paths = simulate_paths(
+            chain, initial=initial, n_steps=n_steps, n_paths=n_paths, seed=2026
+        )
+        empirical = state_distribution_at(paths, step=n_steps, n_states=chain.n_states)
+        e_initial = np.zeros(chain.n_states)
+        e_initial[initial] = 1.0
+        analytical = e_initial @ chain.n_step(n_steps)
+        # 5000 paths gives Monte Carlo error ~ 1/sqrt(5000) ~ 0.014.
+        np.testing.assert_allclose(empirical, analytical, atol=0.03)
+
+
+class TestStateDistributionAt:
+    def test_distribution_sums_to_one(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=0, n_steps=3, n_paths=100, seed=0)
+        dist = state_distribution_at(paths, step=2, n_states=chain.n_states)
+        assert np.isclose(dist.sum(), 1.0)
+        assert (dist >= 0).all()
+        assert dist.shape == (chain.n_states,)
+
+    def test_step_at_zero_is_concentrated(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=2, n_steps=1, n_paths=10, seed=0)
+        dist = state_distribution_at(paths, step=0, n_states=chain.n_states)
+        expected = np.array([0.0, 0.0, 1.0, 0.0])
+        np.testing.assert_allclose(dist, expected)
+
+    def test_invalid_step(self, chain: MarkovChain) -> None:
+        paths = simulate_paths(chain, initial=0, n_steps=2, n_paths=5, seed=0)
+        with pytest.raises(ValueError, match="step"):
+            state_distribution_at(paths, step=99, n_states=chain.n_states)


### PR DESCRIPTION
## Summary

Establish the mathematical language for the rest of the article: define Markov chains formally, prove the Chapman–Kolmogorov equation, classify states, and implement the DTMC computational backbone with a reproducible path simulator.

## Deliverables

### Theory (`notes/phase1-markov-foundations.md`)
- Formal Markov property and row-stochasticity proof
- Theorem: $p_{ij}^{(n)} = (P^n)_{ij}$ by induction on $n$
- Chapman–Kolmogorov equation derived from total probability + Markov property
- Definitions: accessibility, communication, transient/recurrent, absorbing, periodicity
- Proof: communication is an equivalence relation
- Headcount classification: irreducible (recycling) vs. absorbing chain (Exit absorbing)
- Three-state worked example with $P^2$ and $P^3$ computed by hand

### Code
- `src/dtmc.py` — `MarkovChain(P, state_labels)` with:
  - row-stochastic validation
  - `n_step(n)` → $P^n$
  - `evolve(pi0, n)` → $\pi_0 P^n$
  - `stationary()` placeholder (full solver in Phase 2)
  - `is_irreducible()`, `is_absorbing_state(i)`, `is_absorbing()`
  - `communication_classes()` via Warshall transitive closure
- `src/simulation.py` — `simulate_path`, `simulate_paths`, `state_distribution_at`; all randomness through an explicit `numpy.random.Generator` with seed.

### Tests (`tests/`)
- `test_dtmc.py`: validates construction, $P^1 = P$, row sums of $P^n$, Chapman–Kolmogorov identity for several $(m, n)$, the worked-example values for $P^2$ and $P^3$, distribution evolution, and structural properties on the headcount chain.
- `test_simulation.py`: shape, initial state, valid state range, respect of zero-probability arcs, reproducibility under fixed seed, empirical $\to$ analytical convergence at 5{,}000 paths.

### Notebook (`notebooks/01_markov_foundations.ipynb`)
- Reproduces $P^2$, $P^3$ for the three-state example
- Shows recycling vs. absorbing structural classification
- Evolves an all-Juniors initial distribution and compares analytical $P^{12} \cdot e_J$ to a 5000-path empirical estimate

## Validation
- [x] `pytest tests/` passes
- [x] `ruff check .` clean
- [x] Notebook runs end-to-end with `pip install -e ".[dev]"`

Closes #5, #6